### PR TITLE
Add Jest tests for isWeekend

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "jest"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",
@@ -19,6 +20,7 @@
     "sqlite3": "^5.1.6"
   },
   "devDependencies": {
+    "jest": "^30.0.5",
     "nodemon": "^3.0.1"
   }
 }

--- a/server/services/__tests__/dateHelpers.test.js
+++ b/server/services/__tests__/dateHelpers.test.js
@@ -1,0 +1,15 @@
+const { isWeekend } = require('../dateHelpers');
+
+describe('isWeekend', () => {
+  test('returns true for Saturday', () => {
+    expect(isWeekend(new Date('2023-09-09'))).toBe(true);
+  });
+
+  test('returns true for Sunday', () => {
+    expect(isWeekend(new Date('2023-09-10'))).toBe(true);
+  });
+
+  test('returns false for weekday', () => {
+    expect(isWeekend(new Date('2023-09-11'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add simple Jest unit test for dateHelpers.isWeekend
- configure Jest as dev dependency and add `npm test` script

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687f5cf160348324bcf06f0cc8c63496