### PR TITLE
Fix priority mapping in EOM service

### DIFF
--- a/server/services/eomService.js
+++ b/server/services/eomService.js
@@ -55,7 +55,7 @@ class EomService {
             let activeGoals = allAccounts.flatMap(acc => acc.goals).filter(g => g.is_active);
 
             const currentDate = new Date();
-            const priorityOrder = { "High": 1, "Medium": 2, "Low": 3 };
+            const priorityOrder = { high: 1, medium: 2, low: 3 };
 
             activeGoals = activeGoals.map(goal => {
                 const targetDate = new Date(goal.target_date);


### PR DESCRIPTION
## Summary
- prioritize savings goals correctly by using lowercase priority keys

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687f5cdaa348832489a2d0ce176fa32f