### PR TITLE
Fix budget CSV upload month parsing

### DIFF
--- a/server/controllers/budgetController.js
+++ b/server/controllers/budgetController.js
@@ -157,11 +157,13 @@ class BudgetController {
                 // Process budget entries for the row
                 for (const header in rec) {
                     if (header.toLowerCase() !== 'category' && header.toLowerCase() !== 'subcategory') {
-                        const dateParts = header.match(/([a-zA-Z]+)\s*(\d+)/);
+                        const dateParts = header.match(/([a-zA-Z]+)[\s-]*(\d{2,4})/);
                         if (dateParts && dateParts.length === 3) {
                             const monthStr = dateParts[1];
-                            const yearShort = parseInt(dateParts[2], 10);
-                            const yearNum = 2000 + yearShort;
+                            let yearNum = parseInt(dateParts[2], 10);
+                            if (yearNum < 100) {
+                                yearNum += 2000;
+                            }
                             const monthNum = new Date(Date.parse(monthStr + " 1, 2000")).getMonth() + 1;
 
                             const amount = parseFloat(rec[header] || 0);


### PR DESCRIPTION
## Summary
- allow budget CSV upload to parse month columns formatted with spaces or hyphens and 2 or 4-digit years

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6886112f6eec83248920005567cd36f3