### PR TITLE
Fix budget upload header parsing

### DIFF
--- a/server/controllers/budgetController.js
+++ b/server/controllers/budgetController.js
@@ -157,7 +157,8 @@ class BudgetController {
                 // Process budget entries for the row
                 for (const header in rec) {
                     if (header.toLowerCase() !== 'category' && header.toLowerCase() !== 'subcategory') {
-                        const dateParts = header.match(/([a-zA-Z]+)\s*(\d+)/);
+                        // Allow either "Jul 25" or "Jul-25" style headers
+                        const dateParts = header.match(/([a-zA-Z]+)[-\s]*(\d+)/);
                         if (dateParts && dateParts.length === 3) {
                             const monthStr = dateParts[1];
                             const yearShort = parseInt(dateParts[2], 10);


### PR DESCRIPTION
## Summary
- allow hyphenated month headers during budget CSV upload so templates using "Jul-25" parse correctly

## Testing
- `npm test` (server, fails: Missing script)
- `npm test` (client, fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_687f5917c5cc8324979c8f29644fc077