### PR TITLE
Fix budget header date regex

### DIFF
--- a/server/controllers/budgetController.js
+++ b/server/controllers/budgetController.js
@@ -157,7 +157,8 @@ class BudgetController {
                 // Process budget entries for the row
                 for (const header in rec) {
                     if (header.toLowerCase() !== 'category' && header.toLowerCase() !== 'subcategory') {
-                        const dateParts = header.match(/([a-zA-Z]+)[\s-]*(\d{2,4})/);
+                        // Allow either "Jul 25" or "Jul-25" style headers
+                        const dateParts = header.match(/([a-zA-Z]+)[-\s]*(\d+)/);
                         if (dateParts && dateParts.length === 3) {
                             const monthStr = dateParts[1];
                             let yearNum = parseInt(dateParts[2], 10);


### PR DESCRIPTION
## Summary
- parse header budgets with optional hyphen or space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886477985188324aef1a784665f6be5