### PR TITLE
Add sign flip option for import profiles

### DIFF
--- a/client/src/components/settings/ImportProfileManager.jsx
+++ b/client/src/components/settings/ImportProfileManager.jsx
@@ -16,7 +16,9 @@ import {
   Menu,
   MenuItem,
   Box,
-  Typography
+  Typography,
+  FormControlLabel,
+  Switch
 } from '@mui/material';
 import { MoreVert, AddCircle } from '@mui/icons-material';
 
@@ -40,6 +42,7 @@ function ImportProfileManager() {
     e.preventDefault();
     const formData = new FormData(e.target);
     const data = Object.fromEntries(formData.entries());
+    data.flip_amount_sign = formData.has('flip_amount_sign');
     try {
       if (editingProfile) {
         await api.updateImportProfile(editingProfile.id, data);
@@ -194,6 +197,10 @@ function ImportProfileManager() {
                     margin="normal"
                 />
             </Box>
+            <FormControlLabel
+                control={<Switch name="flip_amount_sign" defaultChecked={Boolean(editingProfile?.flip_amount_sign)} />}
+                label="Amounts need sign flipped"
+            />
             <TextField
               name="date_format"
               label="Date Format (Optional)"

--- a/client/src/components/settings/ImportProfileManager.jsx
+++ b/client/src/components/settings/ImportProfileManager.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import * as api from '../../services/api';
 import {
   Button,
@@ -40,6 +40,8 @@ function ImportProfileManager() {
     flip_amount_sign: false
   });
   const [samples, setSamples] = useState([]);
+  const [selectedFile, setSelectedFile] = useState('');
+  const fileInputRef = useRef(null);
 
   const fetchProfiles = () => {
     api.getAllImportProfiles().then(setProfiles).finally(() => setLoading(false));
@@ -76,6 +78,8 @@ function ImportProfileManager() {
 
   const openDialog = (profile = null) => {
     setEditingProfile(profile);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+    setSelectedFile('');
     if (profile) {
       setFormFields({
         profile_name: profile.profile_name,
@@ -120,6 +124,7 @@ function ImportProfileManager() {
   const handleFileChange = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
+    setSelectedFile(file.name);
     try {
       const analysis = await api.analyzeImportProfile(file);
       setFormFields(f => ({
@@ -198,8 +203,19 @@ function ImportProfileManager() {
           <DialogContent>
             <Button variant="outlined" component="label" sx={{ mt: 1 }}>
               Upload Example CSV
-              <input type="file" hidden accept=".csv" onChange={handleFileChange} />
+              <input
+                type="file"
+                hidden
+                accept=".csv"
+                onChange={handleFileChange}
+                ref={fileInputRef}
+              />
             </Button>
+            {selectedFile && (
+              <Typography variant="caption" sx={{ ml: 2 }}>
+                {selectedFile}
+              </Typography>
+            )}
             <TextField
               name="profile_name"
               label="Profile Name"

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -49,6 +49,11 @@ export async function getAllImportProfiles() { return fetchApi('/import-profiles
 export async function createImportProfile(profileData) { return fetchApi('/import-profiles', { method: 'POST', body: JSON.stringify(profileData) }); }
 export async function updateImportProfile(id, profileData) { return fetchApi(`/import-profiles/${id}`, { method: 'PUT', body: JSON.stringify(profileData) }); }
 export async function deleteImportProfile(id) { return fetchApi(`/import-profiles/${id}`, { method: 'DELETE' }); }
+export async function analyzeImportProfile(file) {
+  const formData = new FormData();
+  formData.append('profileFile', file);
+  return fetchApi('/import-profiles/analyze', { method: 'POST', body: formData }, true);
+}
 
 
 // TRANSACTIONS

--- a/server/controllers/importProfileController.js
+++ b/server/controllers/importProfileController.js
@@ -1,4 +1,5 @@
 const ImportProfile = require('../models/ImportProfile');
+const ProfileDetectionService = require('../services/profileDetectionService');
 
 class ImportProfileController {
   static async getAllProfiles(req, res) {
@@ -16,6 +17,16 @@ class ImportProfileController {
       res.status(201).json(profile);
     } catch (error) {
       res.status(500).json({ message: 'Error creating import profile.', error: error.message });
+    }
+  }
+
+  static async analyzeCsv(req, res) {
+    if (!req.file) return res.status(400).json({ message: 'No file uploaded.' });
+    try {
+      const result = ProfileDetectionService.analyze(req.file.buffer);
+      res.status(200).json(result);
+    } catch (error) {
+      res.status(500).json({ message: 'Error analyzing CSV.' });
     }
   }
 

--- a/server/models/ImportProfile.js
+++ b/server/models/ImportProfile.js
@@ -12,25 +12,32 @@ class ImportProfile {
   }
 
   static async create(profileData) {
-    const { profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format } = profileData;
+    const { profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format, flip_amount_sign } = profileData;
     const database = await db.openDb();
     const sql = `
-        INSERT INTO import_profiles (profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format) 
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO import_profiles (profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format, flip_amount_sign)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `;
-    const result = await database.run(sql, [profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format]);
+    const result = await database.run(sql, [profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format, flip_amount_sign ? 1 : 0]);
     return { id: result.lastID, ...profileData };
   }
 
   static async update(id, profileData) {
-    const { profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format } = profileData;
+    const { profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format, flip_amount_sign } = profileData;
     const database = await db.openDb();
     const sql = `
-        UPDATE import_profiles SET 
-        profile_name = ?, date_col = ?, description_col = ?, amount_col = ?, debit_col = ?, credit_col = ?, date_format = ?
+        UPDATE import_profiles SET
+        profile_name = ?,
+        date_col = ?,
+        description_col = ?,
+        amount_col = ?,
+        debit_col = ?,
+        credit_col = ?,
+        date_format = ?,
+        flip_amount_sign = ?
         WHERE id = ?
     `;
-    await database.run(sql, [profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format, id]);
+    await database.run(sql, [profile_name, date_col, description_col, amount_col, debit_col, credit_col, date_format, flip_amount_sign ? 1 : 0, id]);
     return { id, ...profileData };
   }
 

--- a/server/routes/importProfiles.js
+++ b/server/routes/importProfiles.js
@@ -2,9 +2,13 @@ const express = require('express');
 const router = express.Router();
 const ImportProfileController = require('../controllers/importProfileController');
 const isAuthenticated = require('../middleware/isAuthenticated');
+const multer = require('multer');
+const storage = multer.memoryStorage();
+const upload = multer({ storage });
 
 router.use(isAuthenticated);
 
+router.post('/analyze', upload.single('profileFile'), ImportProfileController.analyzeCsv);
 router.get('/', ImportProfileController.getAllProfiles);
 router.post('/', ImportProfileController.createProfile);
 router.put('/:id', ImportProfileController.updateProfile);

--- a/server/services/csvParserService.js
+++ b/server/services/csvParserService.js
@@ -78,6 +78,9 @@ class CsvParserService {
     let amount = 0;
     if (profile.amount_col && row[profile.amount_col]) {
       amount = cleanAndParseFloat(row[profile.amount_col]);
+      if (profile.flip_amount_sign) {
+        amount = -amount;
+      }
     } else if (profile.debit_col && profile.credit_col) {
       const debit = cleanAndParseFloat(row[profile.debit_col]);
       const credit = cleanAndParseFloat(row[profile.credit_col]);

--- a/server/services/profileDetectionService.js
+++ b/server/services/profileDetectionService.js
@@ -1,0 +1,99 @@
+const { parse } = require('csv-parse/sync');
+
+function looksLikeDate(value) {
+  if (!value) return false;
+  const d = new Date(value);
+  if (!isNaN(d.getTime())) return true;
+  const parts = String(value).split(/[\/-]/);
+  if (parts.length === 3) {
+    const dd = parseInt(parts[0], 10);
+    const mm = parseInt(parts[1], 10);
+    const yy = parseInt(parts[2], 10);
+    if (dd > 0 && dd <= 31 && mm > 0 && mm <= 12 && yy > 0) return true;
+  }
+  return false;
+}
+
+function cleanNumber(value) {
+  if (typeof value !== 'string') return NaN;
+  const cleaned = value.replace(/[^0-9.-]+/g, '');
+  return parseFloat(cleaned);
+}
+
+function analyze(buffer) {
+  const records = parse(buffer, {
+    columns: header => header.map(h => h.trim()),
+    skip_empty_lines: true,
+    trim: true,
+    relax_column_count: true
+  });
+  if (records.length === 0) return {};
+
+  const headers = Object.keys(records[0]);
+  const N = Math.min(records.length, 20);
+
+  const numericInfo = {};
+  const dateCandidates = [];
+  const textInfo = {};
+
+  for (const h of headers) {
+    let dateCount = 0;
+    let numValid = 0;
+    let numPos = 0;
+    let numNeg = 0;
+    let lenSum = 0;
+    for (let i = 0; i < N; i++) {
+      const val = records[i][h];
+      if (looksLikeDate(val)) dateCount++;
+      const num = cleanNumber(val);
+      if (!isNaN(num)) {
+        numValid++;
+        if (num > 0) numPos++; else if (num < 0) numNeg++;
+      }
+      lenSum += String(val || '').length;
+    }
+    if (dateCount >= N / 2) {
+      dateCandidates.push(h);
+    } else if (numValid >= N / 2) {
+      numericInfo[h] = { valid: numValid, pos: numPos, neg: numNeg };
+    } else {
+      textInfo[h] = { avg: lenSum / N };
+    }
+  }
+
+  const textCandidates = Object.entries(textInfo).sort((a,b)=>b[1].avg - a[1].avg);
+  const description_col = textCandidates[0] ? textCandidates[0][0] : headers[0];
+
+  const numericCandidates = Object.entries(numericInfo)
+    .filter(([h]) => !/balance/i.test(h) && !/card/i.test(h));
+
+  let amount_col = null;
+  let debit_col = null;
+  let credit_col = null;
+  let flip_amount_sign = false;
+
+  if (numericCandidates.length >= 2) {
+    numericCandidates.sort((a,b)=>b[1].valid - a[1].valid);
+    debit_col = numericCandidates[0][0];
+    credit_col = numericCandidates[1][0];
+    const stats = numericInfo[debit_col];
+    if (stats.pos >= stats.neg) flip_amount_sign = true;
+  } else if (numericCandidates.length === 1) {
+    amount_col = numericCandidates[0][0];
+    const stats = numericInfo[amount_col];
+    if (stats.pos > stats.neg) flip_amount_sign = true;
+  }
+
+  const date_col = dateCandidates[0] || headers[0];
+
+  // sample preview
+  const samples = records.slice(0,5).map(r=>({
+    date: r[date_col],
+    description: r[description_col],
+    amount: amount_col ? r[amount_col] : `${r[debit_col]} / ${r[credit_col]}`
+  }));
+
+  return { date_col, description_col, amount_col, debit_col, credit_col, flip_amount_sign, samples };
+}
+
+module.exports = { analyze };


### PR DESCRIPTION
## Summary
- add `flip_amount_sign` column to import profiles table with migration
- support new column in ImportProfile model
- flip amounts in CSV parser when profile flag is set
- expose switch in ImportProfileManager dialog to toggle sign flipping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886996e43d0832496cc14a6870a3e8b